### PR TITLE
feat!: change nvim-cmp workflow

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -22,7 +22,7 @@ opt.colorcolumn = "80"
 opt.signcolumn = "yes"
 opt.cmdheight = 1
 opt.scrolloff = 10
-opt.completeopt = "menu,menuone,preview,noselect"
+opt.completeopt = "menu,menuone,preview"
 
 -- Behaviour
 opt.hidden = true

--- a/lua/plugins/nvim-cmp.lua
+++ b/lua/plugins/nvim-cmp.lua
@@ -56,23 +56,30 @@ return {
       -- configure lspkind for vs-code like pictograms in completion menu
       formatting = {
         format = lspkind.cmp_format({
-          maxwidth = 30,
+          maxwidth = 40,
           ellipsis_char = "...",
+          menu = {},
+          -- menu = {
+          --   buffer = "[Buffer]",
+          --   nvim_lsp = "[LSP]",
+          --   luasnip = "[Snippet]",
+          --   path = "[Path]",
+          -- },
 
           -- truncate lsp source path
-          before = function(_, item)
-            local MAX_MENU_WIDTH = 20
-            local ELLIPSIS = "..."
-
-            if item.menu ~= nil then
-              local menu = item.menu
-              if #menu > MAX_MENU_WIDTH then
-                item.menu = vim.fn.strcharpart(menu, 0, MAX_MENU_WIDTH)
-                  .. ELLIPSIS
-              end
-            end
-            return item
-          end,
+          -- before = function(_, item)
+          --   local MAX_MENU_WIDTH = 20
+          --   local ELLIPSIS = "..."
+          --
+          --   if item.menu ~= nil then
+          --     local menu = item.menu
+          --     if #menu > MAX_MENU_WIDTH then
+          --       item.menu = vim.fn.strcharpart(menu, 0, MAX_MENU_WIDTH)
+          --         .. ELLIPSIS
+          --     end
+          --   end
+          --   return item
+          -- end,
         }),
       },
     })

--- a/lua/plugins/nvim-cmp.lua
+++ b/lua/plugins/nvim-cmp.lua
@@ -24,8 +24,9 @@ return {
         completion = cmp.config.window.bordered(),
         documentation = cmp.config.window.bordered(),
       },
+      preselect = cmp.PreselectMode.None,
       completion = {
-        completeopt = "menu,menuone,preview,noselect",
+        completeopt = "menu,menuone,preview",
       },
       snippet = { -- configure how nvim-cmp interacts with snippet engine
         expand = function(args)
@@ -51,11 +52,27 @@ return {
         { name = "buffer" }, -- text within current buffer
         { name = "path" }, -- file system paths
       }),
+
       -- configure lspkind for vs-code like pictograms in completion menu
       formatting = {
         format = lspkind.cmp_format({
-          maxwidth = 50,
+          maxwidth = 30,
           ellipsis_char = "...",
+
+          -- truncate lsp source path
+          before = function(_, item)
+            local MAX_MENU_WIDTH = 20
+            local ELLIPSIS = "..."
+
+            if item.menu ~= nil then
+              local menu = item.menu
+              if #menu > MAX_MENU_WIDTH then
+                item.menu = vim.fn.strcharpart(menu, 0, MAX_MENU_WIDTH)
+                  .. ELLIPSIS
+              end
+            end
+            return item
+          end,
         }),
       },
     })

--- a/lua/plugins/nvim-cmp.lua
+++ b/lua/plugins/nvim-cmp.lua
@@ -59,6 +59,7 @@ return {
           maxwidth = 40,
           ellipsis_char = "...",
           menu = {},
+
           -- menu = {
           --   buffer = "[Buffer]",
           --   nvim_lsp = "[LSP]",


### PR DESCRIPTION
- 1st suggestion on autocomplete is auto-selected when typing now.
- stylistic changes to nvim-cmp menu
    - the red part is now removed. redundant and takes up too much space
    - the blue part is now truncated from 50 chars to 40 chars 

![image](https://github.com/leelhn2345/nvim/assets/64735315/0ff3b8d9-db22-43ff-9014-768998d0eb33)
